### PR TITLE
removed 3.7 python version from strategy matrix

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
what:
   - removed `python 3.7` dependency

why:
   - minimum version for `python-api-wrapper` supported is `python 3.8`
 

>Note: This change will not fix the pipeline yet. The current version of the `python-api-wrapper`  **does not** support  `python 3.8`. Support for  `python 3.8` will be included in the next release. Once that release is available and combined with this change, the pipeline will function correctly.